### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/bot/states/settings/channel.ts
+++ b/src/bot/states/settings/channel.ts
@@ -74,7 +74,7 @@ export default async function (i: GenericInteraction, args: [ Options ]): Promis
     .slice(0, 24)
     .map((c) => {
       const p = c.permissionsFor(self)
-      let description = '' // (c as TextChannel).topic?.substr(0, 50) || ''
+      let description = '' // (c as TextChannel).topic?.slice(0, 50) || ''
       if (!p.has('VIEW_CHANNEL')) description = '⚠️ ' + Localisation.text(i.guildData, '=settings_channel_list_warning_missing_view_channel')
       else if (!p.has('MANAGE_WEBHOOKS')) description = '⚠️ ' + Localisation.text(i.guildData, '=settings_channel_list_warning_missing_manage_webhooks')
       else if (!p.has('SEND_MESSAGES')) description = '=settings_channel_list_warning_missing_send_messages'
@@ -148,7 +148,7 @@ export default async function (i: GenericInteraction, args: [ Options ]): Promis
 function sanitizeChannelName(name: string, maxlength: number): string {
   if (name.length < maxlength) return name
 
-  name = name.substr(0, maxlength)
+  name = name.slice(0, maxlength)
   if (name.split('').some(n => n.charCodeAt(0) > 0xFF))
     // eslint-disable-next-line no-control-regex
     name = name.replace(/((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]))/g, '')

--- a/src/bot/states/settings/role.ts
+++ b/src/bot/states/settings/role.ts
@@ -87,7 +87,7 @@ export default async function (i: GenericInteraction): Promise<InteractionApplic
 function sanitizeRoleName(name: string, maxlength: number): string {
   if (name.length < maxlength) return name
 
-  name = name.substr(0, maxlength)
+  name = name.slice(0, maxlength)
   if (name.split('').some(n => n.charCodeAt(0) > 0xFF))
     // eslint-disable-next-line no-control-regex
     name = name.replace(/((?:[\0-\x08\x0B\f\x0E-\x1F\uFFFD\uFFFE\uFFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]))/g, '')

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,7 +33,7 @@ if (process.argv) {
 
       const item = key.split('.')[0]
       overrideConfig(
-        key.substr(item.length + 1),
+        key.slice(item.length + 1),
         value,
         conf[item]
       )


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.